### PR TITLE
Fix display issue on mobile devices

### DIFF
--- a/ftw/faqblock/resources.zcml
+++ b/ftw/faqblock/resources.zcml
@@ -8,7 +8,7 @@
 
     <browser:resourceDirectory name="ftw.faqblock" directory="resources" />
 
-    <theme:resources profile="ftw.faqblock:default" slot="theme">
+    <theme:resources profile="ftw.faqblock:default" slot="addon">
         <theme:scss file="resources/scss/faqblock.scss" />
     </theme:resources>
 

--- a/ftw/faqblock/resources/scss/faqblock.scss
+++ b/ftw/faqblock/resources/scss/faqblock.scss
@@ -28,7 +28,6 @@ $faqblock-border-colour: $color-primary;
     }
 
     span {
-      display: inline-block;
       padding: 0;
     }
   }


### PR DESCRIPTION
This fixes a display issue with long titles.

Before:
<img width="652" alt="screen shot 2018-10-22 at 11 18 46" src="https://user-images.githubusercontent.com/437933/47286290-56ccdf80-d5ee-11e8-9db7-a2afd7ec0a31.png">


After:
<img width="744" alt="screen shot 2018-10-22 at 11 24 22" src="https://user-images.githubusercontent.com/437933/47286299-5df3ed80-d5ee-11e8-8782-91f72defa9b0.png">

Do you see any problems by changing this from display-inline to inline?


I also moved the scss to the right slot.